### PR TITLE
[ADD] mrp_repair_dates_extend: This module in "mrp.repair" object cre…

### DIFF
--- a/mrp_repair_date/README.rst
+++ b/mrp_repair_date/README.rst
@@ -1,0 +1,22 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+================
+MRP repair date
+================
+* This module in "mrp.repair" object creates new fields of dates: Scheduled
+  departure date, start date, end date. Also it is shown in the tree view, the
+  date of creation of the object.
+
+* Have created a new view of type "calendar" for the repair object, taking into
+  account the new Scheduled departure date.
+
+Credits
+=======
+
+Contributors
+------------
+* Ana Juaristi <anajuaristi@avanzosc.es>
+* Oihane Crucelaegui <oihanecrucelaegi@avanzosc.es>
+* Alfredo de la Fuente <alfredodelafuente@avanzosc.es>

--- a/mrp_repair_date/__init__.py
+++ b/mrp_repair_date/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# (c) 2015 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from . import models

--- a/mrp_repair_date/__openerp__.py
+++ b/mrp_repair_date/__openerp__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# (c) 2015 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+{
+    'name': 'MRP Repair Date',
+    "version": "8.0.1.0.0",
+    "license": 'AGPL-3',
+    "author": 'OdooMRP team,'
+              'AvanzOSC,'
+              'Serv. Tecnol. Avanzados - Pedro M. Baeza',
+    'website': "http://www.odoomrp.com",
+    "contributors": [
+        "Ana Juaristi <anajuaristi@avanzosc.es>",
+        "Oihane Crucelaegui <oihanecrucelaegi@avanzosc.es>",
+        "Alfredo de la Fuente <alfredodelafuente@avanzosc.es>",
+        ],
+    'category': 'Manufacturing',
+    'depends': ['mrp_repair',
+                ],
+    'data': ['views/mrp_repair_view.xml',
+             ],
+    'installable': True,
+}

--- a/mrp_repair_date/i18n/es.po
+++ b/mrp_repair_date/i18n/es.po
@@ -1,0 +1,42 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* mrp_repair_date
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-11-20 08:41+0000\n"
+"PO-Revision-Date: 2015-11-20 08:41+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: mrp_repair_date
+#: field:mrp.repair,end_date:0
+msgid "End Date"
+msgstr "Fecha fin"
+
+#. module: mrp_repair_date
+#: model:ir.model,name:mrp_repair_date.model_mrp_repair
+msgid "Repair Order"
+msgstr "Orden reparación"
+
+#. module: mrp_repair_date
+#: view:mrp.repair:mrp_repair_date.view_repair_order_calendar
+msgid "Repair Orders"
+msgstr "Órdenes de reparación"
+
+#. module: mrp_repair_date
+#: field:mrp.repair,scheduled_departure_date:0
+msgid "Scheduled Departure Date"
+msgstr "Fecha prevista salida"
+
+#. module: mrp_repair_date
+#: field:mrp.repair,start_date:0
+msgid "Start Date"
+msgstr "Fecha inicio"
+

--- a/mrp_repair_date/models/__init__.py
+++ b/mrp_repair_date/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# (c) 2015 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from . import mrp_repair

--- a/mrp_repair_date/models/mrp_repair.py
+++ b/mrp_repair_date/models/mrp_repair.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+# (c) 2015 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from openerp import models, fields, api
+
+
+class MrpRepair(models.Model):
+    _inherit = 'mrp.repair'
+
+    scheduled_departure_date = fields.Date(string='Scheduled Departure Date')
+    start_date = fields.Date(string='Start Date', readonly=True)
+    end_date = fields.Date(string='End Date', readonly=True)
+
+    @api.multi
+    def action_repair_start(self):
+        result = super(MrpRepair, self).action_repair_start()
+        self.write({'start_date': fields.Date.context_today(self)})
+        return result
+
+    @api.multi
+    def action_repair_end(self):
+        result = super(MrpRepair, self).action_repair_end()
+        self.write({'end_date': fields.Date.context_today(self)})
+        return result
+
+    @api.multi
+    def action_cancel_draft(self):
+        result = super(MrpRepair, self).action_cancel_draft()
+        self.write({'start_date': False, 'end_date': False})
+        return result

--- a/mrp_repair_date/tests/__init__.py
+++ b/mrp_repair_date/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# (c) 2015 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from . import test_mrp_repair_date

--- a/mrp_repair_date/tests/test_mrp_repair_date.py
+++ b/mrp_repair_date/tests/test_mrp_repair_date.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+# (c) 2015 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+import openerp.tests.common as common
+
+
+class TestMrpRepairDate(common.TransactionCase):
+
+    def setUp(self):
+        super(TestMrpRepairDate, self).setUp()
+        self.data_model = self.env['ir.model.data']
+        fee_vals = {'user_id': self.env.ref('base.user_root').id,
+                    'name': 'Test mrp repair dates',
+                    'product_uom': self.env.ref('product.product_uom_unit').id,
+                    'price_unit': 1,
+                    'product_uom_qty': 5}
+        vals = {'product_id': self.env.ref('product.product_product_8').id,
+                'product_uom': self.env.ref('product.product_uom_unit').id,
+                'location_id': self.env.ref('stock.stock_location_7').id,
+                'location_dest_id': self.env.ref('stock.stock_location_7').id,
+                'fees_lines': [(0, 0, fee_vals)]}
+        self.repair = self.env['mrp.repair'].create(vals)
+
+    def test_mrp_repair_date(self):
+        self.repair.signal_workflow('repair_confirm')
+        self.repair.signal_workflow('repair_ready')
+        self.assertNotEqual(
+            self.repair.start_date, False,
+            'Repair initiated, and is not loaded start date')
+        self.repair.action_cancel()
+        self.repair.action_cancel_draft()
+        self.assertEqual(
+            self.repair.start_date, False,
+            'Repair to draft, and it did not initialize the value of start '
+            'date')
+        self.repair.signal_workflow('repair_confirm')
+        self.repair.signal_workflow('repair_ready')
+        self.repair.signal_workflow('action_repair_end')
+        self.assertNotEqual(
+            self.repair.end_date, False,
+            'Repair finished, and is not loaded end date')

--- a/mrp_repair_date/views/mrp_repair_view.xml
+++ b/mrp_repair_date/views/mrp_repair_view.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="view_repair_order_calendar" model="ir.ui.view">
+            <field name="name">view.repair.order.calendar</field>
+            <field name="model">mrp.repair</field>
+            <field name="arch" type="xml">
+                <calendar string="Repair Orders" color="state" date_start="scheduled_departure_date">
+                    <field name="partner_id"/>
+                    <field name="product_id" />
+                    <field name="create_date" />
+                    <field name="scheduled_departure_date" />
+                    <field name="start_date" />
+                    <field name="end_date" />
+                </calendar>
+            </field>
+        </record>
+        <record id="view_repair_order_tree_inh_datesextend" model="ir.ui.view">
+            <field name="name">view.repair.order.tree.inh.datesextend</field>
+            <field name="model">mrp.repair</field>
+            <field name="inherit_id" ref="mrp_repair.view_repair_order_tree" />
+            <field name="arch" type="xml">
+                <field name="name" position="before">
+                    <field name="create_date" />
+                    <field name="scheduled_departure_date" />
+                    <field name="start_date" />
+                    <field name="end_date" />
+                </field>
+            </field>
+        </record>
+        <record id="view_repair_order_form_inh_datesextend" model="ir.ui.view">
+            <field name="name">view.repair.order.form.inh.datesextend</field>
+            <field name="model">mrp.repair</field>
+            <field name="inherit_id" ref="mrp_repair.view_repair_order_form" />
+            <field name="arch" type="xml">
+                <field name="guarantee_limit" position="after">
+                    <field name="create_date" />
+                    <field name="scheduled_departure_date" />
+                    <field name="start_date" />
+                    <field name="end_date" />
+                </field>
+            </field>
+        </record>
+         <record id="mrp_repair.action_repair_order_tree" model="ir.actions.act_window">
+            <field name="view_mode">tree,form,calendar</field>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
…ates new fields of dates: Scheduled departure date, start date, end date.

Nuevo módulo para crear 3 nuevas fechas en las órdenes de reparación. Fecha prevista salida, fecha inicio, y fecha fin. Al iniciar la reparación automáticamente se cargará la fecha de inicio con la fecha del sistema, y al finalizar la reparación se cargará automaticamente la fecha fin.
