### PR TITLE
[ADD] new module mrp_repair_proforma

### DIFF
--- a/mrp_repair_proforma_report/README.rst
+++ b/mrp_repair_proforma_report/README.rst
@@ -1,0 +1,18 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+==========================
+Machine manager preventive
+==========================
+
+This module add the 'proforma' checkbox to repair orders. If this check is
+checked, the mrp repair report header changes to 'Proforma'.
+
+Credits
+=======
+
+Contributors
+------------
+* Esther Martín <esthermartin@avanzosc.es>
+* Ana Juaristi <anajuaristi@avanzosc.es>

--- a/mrp_repair_proforma_report/__init__.py
+++ b/mrp_repair_proforma_report/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# (c) 2015 Esther Martín - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from . import models

--- a/mrp_repair_proforma_report/__openerp__.py
+++ b/mrp_repair_proforma_report/__openerp__.py
@@ -11,7 +11,7 @@
     "author": "AvanzOSC",
     "contributors": [
         "Esther Martín <esthermartin@avanzosc.es>",
-        "Ana Juaristi <ajuaristio@gmail.com>",
+        "Ana Juaristi <anajuaristi@avanzosc.es>",
     ],
     "category": "Manufacturing",
     "website": "http://www.avanzosc.es",

--- a/mrp_repair_proforma_report/__openerp__.py
+++ b/mrp_repair_proforma_report/__openerp__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# (c) 2015 Esther Martín - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+{
+    "name": "Mrp Repair - Proforma Report",
+    "version": "8.0.1.0.0",
+    "depends": [
+        "mrp_repair",
+    ],
+    "author": "AvanzOSC",
+    "contributors": [
+        "Esther Martín <esthermartin@avanzosc.es>",
+        "Ana Juaristi <ajuaristio@gmail.com>",
+    ],
+    "category": "Manufacturing",
+    "website": "http://www.avanzosc.es",
+    "data": [
+        "views/mrp_repair_report.xml",
+        "views/mrp_repair_view.xml",
+    ],
+    "installable": True,
+}

--- a/mrp_repair_proforma_report/models/__init__.py
+++ b/mrp_repair_proforma_report/models/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# (c) 2015 Esther Martín - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from . import mrp_repair

--- a/mrp_repair_proforma_report/models/mrp_repair.py
+++ b/mrp_repair_proforma_report/models/mrp_repair.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+# (c) 2015 Esther Martín - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from openerp import fields, models
+
+
+class MrpRepair(models.Model):
+    _inherit = 'mrp.repair'
+
+    proforma = fields.Boolean(string='Proforma')

--- a/mrp_repair_proforma_report/views/mrp_repair_report.xml
+++ b/mrp_repair_proforma_report/views/mrp_repair_report.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <template id="report_mrprepair_proforma" inherit_id="mrp_repair.report_mrprepairorder">
+            <xpath expr="//div[@class='page']/h2" position="replace">
+                <h2>
+                    <span t-if="o.state != 'draft' and o.proforma == False">Repair Order N°:</span>
+                    <span t-if="o.state == 'draft' and o.proforma == False">Repair Quotation N°:</span>
+                    <span t-if="o.proforma == True">Proforma Nº:</span>
+                    <span t-field="o.name"/>
+                </h2>
+            </xpath>
+        </template>
+    </data>
+</openerp>

--- a/mrp_repair_proforma_report/views/mrp_repair_view.xml
+++ b/mrp_repair_proforma_report/views/mrp_repair_view.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <record id="mrp_repair_proforma_view_form" model="ir.ui.view">
+            <field name="name">mrp.repair.proforma.form</field>
+            <field name="model">mrp.repair</field>
+            <field name="inherit_id" ref="mrp_repair.view_repair_order_form"/>
+            <field name="arch" type="xml">
+                <h1 position="after">
+                    <label for="proforma" />
+                    <field name="proforma" />
+                </h1>
+            </field>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
Al igual que hicimos en pedidos de venta -->
Incluir un check "proforma" en la reparación.

Si el check está clickado, el informe de presupuesto debe sacar el título "proforma" en vez de "presupuesto, lo mismo si la orden esta confirmada
