### PR TITLE
[ADD] mrp_repair_estimated_qty: new module

### DIFF
--- a/mrp_repair_estimated_qty/README.rst
+++ b/mrp_repair_estimated_qty/README.rst
@@ -1,0 +1,17 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+========================
+MRP repair estimated qty
+========================
+This module creates new estimated qty field in mrp repair operation lines.
+
+Credits
+=======
+
+Contributors
+------------
+* Ainara Galdona <ainaragaldona@avanzosc.es>
+* Ana Juaristi <anajuaristi@avanzosc.es>
+

--- a/mrp_repair_estimated_qty/__init__.py
+++ b/mrp_repair_estimated_qty/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# (c) 2015 Ainara Galdona - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from . import models

--- a/mrp_repair_estimated_qty/__openerp__.py
+++ b/mrp_repair_estimated_qty/__openerp__.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+# (c) 2015 Ainara Galdona - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+{
+    "name": "MRP Repair Estimated Qty",
+    "version": "8.0.1.0.0",
+    "license": "AGPL-3",
+    "author": "AvanzOSC",
+    "website": "http://www.avanzosc.es",
+    "contributors": [
+        "Ainara Galdona <ainaragaldona@avanzosc.es>",
+        "Ana Juaristi <anajuaristi@avanzosc.es>",
+    ],
+    "category": "Manufacturing",
+    "depends": [
+        "mrp_repair_estimated_cost",
+        "mrp_repair_fee",
+    ],
+    "data": [
+        "views/mrp_repair_view.xml"
+    ],
+    "installable": True,
+}

--- a/mrp_repair_estimated_qty/i18n/es.po
+++ b/mrp_repair_estimated_qty/i18n/es.po
@@ -1,0 +1,37 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* mrp_repair_estimated_qty
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-01-19 18:00+0000\n"
+"PO-Revision-Date: 2016-01-19 18:00+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: mrp_repair_estimated_qty
+#: field:mrp.repair.line,expected_qty:0
+msgid "Expected Qty"
+msgstr "Cantidad Prevista"
+
+#. module: mrp_repair_estimated_qty
+#: model:ir.model,name:mrp_repair_estimated_qty.model_mrp_repair_line
+msgid "Repair Line"
+msgstr "Línea reparación"
+
+#. module: mrp_repair_estimated_qty
+#: model:ir.model,name:mrp_repair_estimated_qty.model_mrp_repair
+msgid "Repair Order"
+msgstr "Orden reparación"
+
+#. module: mrp_repair_estimated_qty
+#: view:mrp.repair:mrp_repair_estimated_qty.view_repair_order_form
+msgid "{'default_product_uom_qty': 0, 'default_expected_qty': product_qty}"
+msgstr "{'default_product_uom_qty': 0, 'default_expected_qty': product_qty}"
+

--- a/mrp_repair_estimated_qty/models/__init__.py
+++ b/mrp_repair_estimated_qty/models/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# (c) 2015 Ainara Galdona - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from . import mrp_repair

--- a/mrp_repair_estimated_qty/models/mrp_repair.py
+++ b/mrp_repair_estimated_qty/models/mrp_repair.py
@@ -1,0 +1,104 @@
+# -*- coding: utf-8 -*-
+# (c) 2015 Ainara Galdona - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from openerp import models, fields, api
+from openerp.addons import decimal_precision as dp
+
+
+class MrpRepairLine(models.Model):
+
+    _inherit = 'mrp.repair.line'
+
+    @api.multi
+    @api.depends('product_id', 'product_uom_qty', 'expected_qty')
+    def _compute_cost_subtotal(self):
+        for line in self:
+            qty = line.expected_qty or line.product_uom_qty
+            line.standard_price = line.product_id.standard_price
+            line.cost_subtotal = line.product_id.standard_price * qty
+
+    @api.multi
+    @api.depends('expected_qty', 'product_uom_qty', 'price_unit', 'product_id',
+                 'tax_id', 'repair_id.partner_id',
+                 'repair_id.pricelist_id.currency_id')
+    def _get_line_subtotal(self):
+        for line in self:
+            qty = line.expected_qty or line.product_uom_qty
+            taxes = line.tax_id.compute_all(
+                line.price_unit, qty, line.product_id,
+                line.repair_id.partner_id)
+            cur = line.repair_id.pricelist_id.currency_id
+            subtotal = cur.round(taxes['total'])
+            line.price_subtotal = subtotal
+
+    expected_qty = fields.Float(string='Expected Qty',
+                                digits=dp.get_precision(
+                                    'Product Unit of Measure'))
+    product_uom_qty = fields.Float(string='Real Qty', default=0)
+    price_subtotal = fields.Float(compute='_get_line_subtotal')
+
+    @api.multi
+    def write(self, vals):
+        res = super(MrpRepairLine, self).write(vals)
+        inv_line_obj = self.env['account.invoice.line']
+        for line in self:
+            if vals.get('invoiced', False) and line.expected_qty and \
+                    vals.get('invoice_line_id', False):
+                invoice_line = inv_line_obj.browse(vals.get('invoice_line_id'))
+                invoice_line.write({'quantity': self.expected_qty})
+        return res
+
+    def product_id_change(self, cr, uid, ids, pricelist, product, uom=False,
+                          product_uom_qty=0, partner_id=False,
+                          guarantee_limit=False, context=None):
+        res = super(MrpRepairLine, self).product_id_change(
+            cr, uid, ids, pricelist, product, uom=uom,
+            product_uom_qty=product_uom_qty, partner_id=partner_id,
+            guarantee_limit=guarantee_limit, context=context)
+        if product_uom_qty == 0:
+            res['value']['product_uom_qty'] = 0
+        return res
+
+
+class MrpRepair(models.Model):
+
+    _inherit = 'mrp.repair'
+
+    def _catch_repair_line_information_for_analytic(self, line):
+        res = super(MrpRepair,
+                    self)._catch_repair_line_information_for_analytic(line)
+        ctx = self.env.context
+        if (not line._name == 'mrp.repair.line' or not line.expected_qty or not
+                ctx.get('load_estimated', False)):
+            return res
+        if res:
+            res['unit_amount'] = line.expected_qty
+            res['repair_estim_amount'] = (line.product_id.standard_price *
+                                          line.expected_qty * -1)
+            res['amount'] = 0
+        else:
+            analytic_line_obj = self.env['account.analytic.line']
+            journal = self.env.ref('mrp.analytic_journal_repair', False)
+            name = self.name
+            if line.product_id.default_code:
+                name += ' - ' + line.product_id.default_code
+            categ_id = line.product_id.categ_id
+            general_account = (line.product_id.property_account_income or
+                               categ_id.property_account_income_categ or False)
+            amount = line.product_id.standard_price * line.expected_qty * -1
+            res = {
+                'name': name,
+                'user_id': line.user_id.id,
+                'date': analytic_line_obj._get_default_date(),
+                'product_id': line.product_id.id,
+                'unit_amount': line.expected_qty,
+                'product_uom_id': line.product_uom.id,
+                'amount': 0,
+                'repair_estim_amount': amount,
+                'journal_id': journal.id,
+                'account_id': self.analytic_account.id,
+                'is_repair_cost': True,
+                'general_account_id': general_account.id
+                }
+        return res

--- a/mrp_repair_estimated_qty/tests/__init__.py
+++ b/mrp_repair_estimated_qty/tests/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# (c) 2015 Ainara Galdona - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from . import test_mrp_repair_estimated_qty

--- a/mrp_repair_estimated_qty/tests/test_mrp_repair_estimated_qty.py
+++ b/mrp_repair_estimated_qty/tests/test_mrp_repair_estimated_qty.py
@@ -1,0 +1,151 @@
+# -*- coding: utf-8 -*-
+# (c) 2015 Ainara Galdona - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+import openerp.tests.common as common
+
+
+class TestMrpRepairEstimatedQty(common.TransactionCase):
+
+    def setUp(self):
+        super(TestMrpRepairEstimatedQty, self).setUp()
+        self.mrp_repair_model = self.env['mrp.repair']
+        self.analytic_account_model = self.env['account.analytic.account']
+        self.analytic_line_model = self.env['account.analytic.line']
+        analytic_vals = {
+            'name': 'Repair Cost Account',
+            'type': 'normal',
+            }
+        self.analytic_id = self.analytic_account_model.create(analytic_vals)
+        # Product: Webcam -- Standard Price: 38.0
+        self.op_product = self.env.ref('product.product_product_34')
+        default_location = self.mrp_repair_model._default_stock_location()
+        op_val = {
+            'product_id': self.op_product.id,
+            'product_uom_qty': 3,
+            'expected_qty': 2,
+            'name': self.op_product.name,
+            'product_uom': self.op_product.uom_id.id,
+            'type': 'add',
+            'location_id': default_location,
+            'location_dest_id': self.op_product.property_stock_production.id,
+            'price_unit': 1.5,
+            'to_invoice': True,
+            'load_cost': True,
+            }
+        self.op_amount = (-1 * self.op_product.standard_price * 2)
+        # Product: On Site Monitoring -- Standard Price: 20.5
+        self.op2_product = self.env.ref('product.product_product_1')
+        op_val2 = {
+            'product_id': self.op2_product.id,
+            'product_uom_qty': 3,
+            'expected_qty': 0,
+            'name': self.op2_product.name,
+            'product_uom': self.op2_product.uom_id.id,
+            'type': 'add',
+            'location_id': default_location,
+            'location_dest_id': self.op2_product.property_stock_production.id,
+            'price_unit': 2,
+            'to_invoice': True,
+            'load_cost': True,
+            }
+        self.op2_amount = (-1 * self.op2_product.standard_price * 3)
+        self.repair_product = self.env.ref('product.product_product_27')
+        repair_vals = {
+            'analytic_account': self.analytic_id.id,
+            'product_uom': self.repair_product.uom_id.id,
+            'product_id': self.repair_product.id,
+            'partner_id': self.env.ref('base.res_partner_8').id,
+            'location_id': default_location,
+            'location_dest_id': default_location,
+            'operations': [(0, 0, op_val), (0, 0, op_val2)],
+            'invoice_method': 'after_repair',
+            'partner_invoice_id': self.env.ref('base.res_partner_8').id
+            }
+        self.mrp_repair = self.mrp_repair_model.create(repair_vals)
+
+    def test_mrp_repair_line_subtotal(self):
+        op_line = self.mrp_repair.operations.filtered(
+            lambda x: x.product_id.id == self.op_product.id)
+        op2_line = self.mrp_repair.operations.filtered(
+            lambda x: x.product_id.id == self.op2_product.id)
+        self.assertEqual(op_line.price_subtotal, 3,
+                         "Incorrect subtotal with expected amount.")
+        self.assertEqual(op2_line.price_subtotal, 6,
+                         "Incorrect subtotal with no expected amount.")
+
+    def test_mrp_repair_line_cost_subtotal(self):
+        op_line = self.mrp_repair.operations.filtered(
+            lambda x: x.product_id.id == self.op_product.id)
+        op2_line = self.mrp_repair.operations.filtered(
+            lambda x: x.product_id.id == self.op2_product.id)
+        self.assertEqual(op_line.cost_subtotal,
+                         (self.op_product.standard_price * 2),
+                         "Incorrect cost subtotal with expected amount.")
+        self.assertEqual(op2_line.cost_subtotal,
+                         (self.op2_product.standard_price * 3),
+                         "Incorrect cost subtotal with no expected amount.")
+
+    def test_mrp_repair_create_cost_with_estimated_qty_confirm(self):
+        self.mrp_repair.signal_workflow('repair_confirm')
+        ope_line = self.analytic_line_model.search(
+            [('account_id', '=', self.analytic_id.id),
+             ('product_id', '=', self.op_product.id),
+             ('unit_amount', '=', 2),
+             ('is_repair_cost', '=', True),
+             ('amount', '=', 0),
+             ('repair_estim_amount', '=', self.op_amount)])
+        fee_line = self.analytic_line_model.search(
+            [('account_id', '=', self.analytic_id.id),
+             ('product_id', '=', self.op2_product.id),
+             ('unit_amount', '=', 3),
+             ('is_repair_cost', '=', True),
+             ('amount', '=', 0),
+             ('repair_estim_amount', '=', self.op2_amount)])
+        self.assertNotEqual(len(ope_line), 0,
+                            "Operation with expected qty line not found.")
+        self.assertNotEqual(len(fee_line), 0,
+                            "Operation with not expected qty line not found.")
+
+    def test_mrp_repair_create_cost_with_zero_uom_qty_confirm(self):
+        op_line = self.mrp_repair.operations.filtered(
+            lambda x: x.product_id.id == self.op_product.id)
+        op_line.product_uom_qty = 0
+        self.mrp_repair.signal_workflow('repair_confirm')
+        ope_line = self.analytic_line_model.search(
+            [('account_id', '=', self.analytic_id.id),
+             ('product_id', '=', self.op_product.id),
+             ('unit_amount', '=', 2),
+             ('is_repair_cost', '=', True),
+             ('amount', '=', 0),
+             ('repair_estim_amount', '=', self.op_amount)])
+        fee_line = self.analytic_line_model.search(
+            [('account_id', '=', self.analytic_id.id),
+             ('product_id', '=', self.op2_product.id),
+             ('unit_amount', '=', 3),
+             ('is_repair_cost', '=', True),
+             ('amount', '=', 0),
+             ('repair_estim_amount', '=', self.op2_amount)])
+        self.assertNotEqual(len(ope_line), 0,
+                            "Operation with expected qty line not found.")
+        self.assertNotEqual(len(fee_line), 0,
+                            "Operation with not expected qty line not found.")
+
+    def test_mrp_repair_invoice_with_expected_qty(self):
+        self.mrp_repair.signal_workflow('repair_confirm')
+        self.mrp_repair.action_invoice_create()
+        for line in self.mrp_repair.operations:
+            qty = line.product_uom_qty
+            if line.expected_qty:
+                qty = line.expected_qty
+            self.assertEqual = (line.invoice_line_id.quantity, qty,
+                                "Incorrect invoice line qty.")
+
+    def test_mrp_repair_line_product_change(self):
+        repair_line_obj = self.env['mrp.repair.line']
+        res = repair_line_obj.product_id_change(
+            self.mrp_repair.pricelist_id.id, self.op2_product.id,
+            uom=self.op2_product.uom_id.id, product_uom_qty=0,
+            partner_id=self.mrp_repair.partner_id.id)
+        self.assertEqual = (res['value']['product_uom_qty'], 0,
+                            "Product uom qty changed in onchange.")

--- a/mrp_repair_estimated_qty/views/mrp_repair_view.xml
+++ b/mrp_repair_estimated_qty/views/mrp_repair_view.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <record id="view_repair_order_form" model="ir.ui.view">
+            <field name="name">mrp.repair.estimated.qty.form</field>
+            <field name="model">mrp.repair</field>
+            <field name="inherit_id" ref="mrp_repair.view_repair_order_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='operations']/tree//field[@name='product_uom_qty']" position="after">
+                   <field name="expected_qty"/>
+                </xpath>
+                <xpath expr="//field[@name='operations']" position="attributes">
+                    <attribute name="context">{'default_product_uom_qty': 0, 'default_expected_qty': product_qty}</attribute>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
SOLICITUD CLIENTE:

Incluir en líneas de material un campo "cantidad presupuestada"
El actual campo cantidad, será "cantidad real" (cambiar etiqueta)
Por defecto, el campo cantidad actual será igual a cero.

Al generar la factura, las cantidades de la línea tiene que coger por defecto, este nuevo campo "cantidad presupuestada"
SOLO cogerá el campo el campo "cantidad real" cuando se cumpla:
Cantidad presupuestada = cero y casilla "a facturar" clickado. En este caso debe coger el campo "real"

Costes estimados se crearán con la cantidad presupuestada
Costes reales se crearán con la cantidad REAL
