### PR TITLE
[IMP] mrp_repair_date: Not initialize Scheduled Departure Date field …

### DIFF
--- a/mrp_repair_date/models/mrp_repair.py
+++ b/mrp_repair_date/models/mrp_repair.py
@@ -8,8 +8,7 @@ class MrpRepair(models.Model):
     _inherit = 'mrp.repair'
 
     scheduled_departure_date = fields.Date(
-        string='Scheduled Departure Date', required=True, copy=False,
-        default=lambda self: fields.Date.context_today(self))
+        string='Scheduled Departure Date', copy=False)
     start_date = fields.Date(
         string='Start Date', readonly=True, copy=False)
     end_date = fields.Date(

--- a/mrp_repair_date/views/mrp_repair_view.xml
+++ b/mrp_repair_date/views/mrp_repair_view.xml
@@ -38,7 +38,7 @@
             <field name="arch" type="xml">
                 <field name="guarantee_limit" position="after">
                     <field name="create_date" />
-                    <field name="scheduled_departure_date" />
+                    <field name="scheduled_departure_date" required="True" />
                     <field name="start_date" />
                     <field name="end_date" />
                 </field>


### PR DESCRIPTION
…in repairs.
Se ha modificado el módulo para no inicializar con la fecha del sistema el campo "fecha prevista salida" de las reparaciones. Este requerimiento se ha solicitado por reclamación en OdooMRP 230 - Fecha salida prevista obligatoria en reparación
