### PR TITLE
[IMP] mrp_repair_estimated_cost, mrp_repair_estimated_qty, mrp_repair_fee: cambio de datos entre modulos

### DIFF
--- a/mrp_repair_estimated_cost/models/mrp_repair.py
+++ b/mrp_repair_estimated_cost/models/mrp_repair.py
@@ -53,7 +53,6 @@ class MrpRepair(models.Model):
         if res and ctx.get('load_estimated', False):
             res['repair_estim_amount'] = res.get('amount', 0)
             res['amount'] = 0
-            return res
         return res
 
     @api.multi

--- a/mrp_repair_estimated_cost/tests/test_mrp_repair_estimated_cost.py
+++ b/mrp_repair_estimated_cost/tests/test_mrp_repair_estimated_cost.py
@@ -15,9 +15,13 @@ class TestMrpRepairAnalytic(TestMrpRepairAnalytic):
             self.mrp_repair.signal_workflow('repair_confirm')
 
     def test_mrp_repair_cero_amount_cost(self):
+        self.op_product.cost_method = 'average'
+        self.op_product.standard_price = 0
+        for op in self.mrp_repair.operations:
+            if self.op_product == op.product_id:
+                op.product_uom_qty = 12
         self.mrp_repair.signal_workflow('repair_confirm')
         self.mrp_repair.create_repair_cost()
-        self.op_product.standard_price = 0
         ope_line = self.analytic_line_model.search(
             [('account_id', '=', self.analytic_id.id),
              ('product_id', '=', self.op_product.id),
@@ -101,7 +105,7 @@ class TestMrpRepairEstimatedCost(TestMrpRepairAnalytic):
     def test_real_cost_lines(self):
         self.mrp_repair.signal_workflow('repair_confirm')
         self.mrp_repair.create_repair_cost()
-        self.assertEqual(len(self.mrp_repair.repair_real_lines), 2,
+        self.assertEqual(len(self.mrp_repair.repair_real_lines), 3,
                          "There quantity of real lines is not correct.")
         for line in self.mrp_repair.repair_real_lines:
             self.assertNotEqual(line.amount, 0,
@@ -109,7 +113,7 @@ class TestMrpRepairEstimatedCost(TestMrpRepairAnalytic):
 
     def test_estimated_cost_lines(self):
         self.mrp_repair.signal_workflow('repair_confirm')
-        self.assertEqual(len(self.mrp_repair.repair_estim_lines), 2,
+        self.assertEqual(len(self.mrp_repair.repair_estim_lines), 3,
                          "There quantity of estimated lines is not correct.")
         for line in self.mrp_repair.repair_estim_lines:
             self.assertNotEqual(line.repair_estim_amount, 0,

--- a/mrp_repair_estimated_qty/__openerp__.py
+++ b/mrp_repair_estimated_qty/__openerp__.py
@@ -15,7 +15,6 @@
     "category": "Manufacturing",
     "depends": [
         "mrp_repair_estimated_cost",
-        "mrp_repair_fee",
     ],
     "data": [
         "views/mrp_repair_view.xml"

--- a/mrp_repair_estimated_qty/models/mrp_repair.py
+++ b/mrp_repair_estimated_qty/models/mrp_repair.py
@@ -69,36 +69,11 @@ class MrpRepair(models.Model):
         res = super(MrpRepair,
                     self)._catch_repair_line_information_for_analytic(line)
         ctx = self.env.context
-        if (not line._name == 'mrp.repair.line' or not line.expected_qty or not
-                ctx.get('load_estimated', False)):
+        if (not line._name == 'mrp.repair.line' or not line.cost_subtotal or
+                not ctx.get('load_estimated', False) or not line.expected_qty):
             return res
-        if res:
-            res['unit_amount'] = line.expected_qty
-            res['repair_estim_amount'] = (line.product_id.standard_price *
-                                          line.expected_qty * -1)
-            res['amount'] = 0
-        else:
-            analytic_line_obj = self.env['account.analytic.line']
-            journal = self.env.ref('mrp.analytic_journal_repair', False)
-            name = self.name
-            if line.product_id.default_code:
-                name += ' - ' + line.product_id.default_code
-            categ_id = line.product_id.categ_id
-            general_account = (line.product_id.property_account_income or
-                               categ_id.property_account_income_categ or False)
-            amount = line.product_id.standard_price * line.expected_qty * -1
-            res = {
-                'name': name,
-                'user_id': line.user_id.id,
-                'date': analytic_line_obj._get_default_date(),
-                'product_id': line.product_id.id,
-                'unit_amount': line.expected_qty,
-                'product_uom_id': line.product_uom.id,
-                'amount': 0,
-                'repair_estim_amount': amount,
-                'journal_id': journal.id,
-                'account_id': self.analytic_account.id,
-                'is_repair_cost': True,
-                'general_account_id': general_account.id
-                }
+        # siempre habra un res, si hay line.cost_subtotal
+        res['unit_amount'] = line.expected_qty
+        res['repair_estim_amount'] = (line.cost_subtotal * -1)
+        res['amount'] = 0
         return res

--- a/mrp_repair_estimated_qty/tests/test_mrp_repair_estimated_qty.py
+++ b/mrp_repair_estimated_qty/tests/test_mrp_repair_estimated_qty.py
@@ -19,6 +19,8 @@ class TestMrpRepairEstimatedQty(common.TransactionCase):
         self.analytic_id = self.analytic_account_model.create(analytic_vals)
         # Product: Webcam -- Standard Price: 38.0
         self.op_product = self.env.ref('product.product_product_34')
+        self.op_product.cost_method = 'average'
+        self.op_product.standard_price = 30
         default_location = self.mrp_repair_model._default_stock_location()
         op_val = {
             'product_id': self.op_product.id,

--- a/mrp_repair_fee/views/mrp_repair_fee_view.xml
+++ b/mrp_repair_fee/views/mrp_repair_fee_view.xml
@@ -55,10 +55,10 @@
                     <field name="product_uom" string="Unit of Measure"
                            groups="product.group_uom" />
                      <field name="standard_price" />
+                    <field name="cost_subtotal" sum="Cost Subtotal"/>
                     <field name="price_unit" />
                     <field name="tax_id" invisible="1"/>
                     <field name="to_invoice" invisible="1"/>
-                    <field name="cost_subtotal" sum="Cost Subtotal"/>
                     <field name="price_subtotal" sum="Price Subtotal"/>
                 </tree>
             </field>
@@ -101,8 +101,9 @@
                             </div>
                         </group>
                         <group>
-                            <field name="price_unit" />
                             <field name="standard_price" />
+                            <field name="cost_subtotal" sum="Cost Subtotal"/>
+                            <field name="price_unit" />
                             <field widget="many2many_tags" name="tax_id"
                                    domain="[('parent_id','=',False),('type_tax_use','&lt;&gt;','purchase')]" />
                             <field name="price_subtotal" />

--- a/mrp_repair_fee/views/mrp_repair_view.xml
+++ b/mrp_repair_fee/views/mrp_repair_view.xml
@@ -6,21 +6,6 @@
             <field name="model">mrp.repair</field>
             <field name="inherit_id" ref="mrp_repair.view_repair_order_form" />
             <field name="arch" type="xml">
-                <xpath expr="//field[@name='operations']//form//field[@name='price_unit']" position="before">
-                    <field name="standard_price" />
-                </xpath>
-                <xpath expr="//field[@name='operations']//tree//field[@name='price_unit']" position="before">
-                    <field name="standard_price" />
-                </xpath>
-                <xpath expr="//field[@name='operations']//form//field[@name='price_subtotal']" position="before">
-                    <field name="cost_subtotal" />
-                </xpath>
-                <xpath expr="//field[@name='operations']//tree//field[@name='price_subtotal']" position="before">
-                    <field name="cost_subtotal" sum="Operations cost subtotal"/>
-                </xpath>
-                <xpath expr="//field[@name='operations']//tree//field[@name='price_subtotal']" position="attributes">
-                    <attribute name="sum">Operations price subtotal</attribute>
-                </xpath>
                 <xpath expr="//field[@name='operations']//tree//field[@name='product_uom_qty']" position="attributes">
                     <attribute name="sum">Sum qty</attribute>
                 </xpath>
@@ -58,10 +43,10 @@
                                 </group>
                                 <group>
                                     <field name="standard_price" />
+                                    <field name="cost_subtotal" />
                                     <field name="price_unit" />
                                     <field name="tax_id" widget="many2many_tags"
                                            domain="[('parent_id','=',False),('type_tax_use','&lt;&gt;','purchase')]" />
-                                    <field name="cost_subtotal" />
                                     <field name="price_subtotal" />
                                 </group>
                             </group>
@@ -86,12 +71,12 @@
                             <field name="product_uom" string="Unit of Measure"
                                    groups="product.group_uom" />
                             <field name="standard_price" />
+                            <field name="cost_subtotal" sum="Cost Subtotal to invoice"/>
                             <field name="price_unit" />
                             <field name="tax_id"
                                    domain="[('parent_id', '=', False), ('type_tax_use', '=', 'purchase')]"
                                    widget="many2many_tags" />
                             <field name="to_invoice" />
-                            <field name="cost_subtotal" sum="Cost Subtotal to invoice"/>
                             <field name="price_subtotal" sum="Price Subtotal to invoice"/>
                         </tree>
                     </field>
@@ -122,11 +107,11 @@
                                 </group>
                                 <group>
                                     <field name="standard_price" />
+                                    <field name="cost_subtotal" />
                                     <field name="price_unit" />
                                     <field widget="many2many_tags"
                                            name="tax_id"
                                            domain="[('parent_id','=',False),('type_tax_use','&lt;&gt;','purchase')]" />
-                                    <field name="cost_subtotal" />
                                     <field name="price_subtotal" />
                                 </group>
                             </group>
@@ -151,12 +136,12 @@
                             <field name="product_uom" string="Unit of Measure"
                                    groups="product.group_uom" />
                             <field name="standard_price" />
+                            <field name="cost_subtotal" sum="Cost Subtotal not to invoice"/>
                             <field name="price_unit" />
                             <field name="tax_id"
                                    domain="[('parent_id', '=', False), ('type_tax_use', '=', 'purchase')]"
                                    widget="many2many_tags" />
                             <field name="to_invoice" />
-                            <field name="cost_subtotal" sum="Cost Subtotal not to invoice"/>
                             <field name="price_subtotal" sum="Price Subtotal not to invoice"/>
                         </tree>
                     </field>


### PR DESCRIPTION
Hemos pasado los campos standard_price y cost_subtotal al módulo de mrp_repair_analytic. Ya que tiene más sentido que se generen ahí a que se generen en mrp_repair_fee. Por otro lado, cargamos el coste de la línea directamente en analítica en vez de hacer cálculos erroneos.
